### PR TITLE
챌린지 메인페이지 api 카테고리 리스트가 중복값을 포함하지 않게 업데이트

### DIFF
--- a/src/main/java/com/example/onedaypiece/service/ChallengeService.java
+++ b/src/main/java/com/example/onedaypiece/service/ChallengeService.java
@@ -13,7 +13,6 @@ import com.example.onedaypiece.web.dto.request.challenge.PutChallengeRequestDto;
 import com.example.onedaypiece.web.dto.response.challenge.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -104,11 +103,14 @@ public class ChallengeService {
     private List<ChallengeSourceResponseDto> categoryCollector(CategoryName category, List<ChallengeRecord> records) {
         final int categorySize = 3;
 
-        List<ChallengeRecord> recordList = records
-                .stream()
-                .filter(r -> r.getChallenge().getCategoryName().equals(category))
-                .limit(categorySize)
-                .collect(Collectors.toList());
+        Set<Long> recordIdList = new HashSet<>();
+        List<ChallengeRecord> recordList = new ArrayList<>();
+        records.stream().filter(r -> !recordIdList.contains(r.getChallenge().getChallengeId()) &&
+                r.getChallenge().getCategoryName().equals(category) &&
+                recordIdList.size() < categorySize).forEach(r -> {
+            recordIdList.add(r.getChallenge().getChallengeId());
+            recordList.add(r);
+        });
         List<ChallengeSourceResponseDto> categorySourceList = new ArrayList<>();
 
         for (Challenge c : recordList.stream().map(ChallengeRecord::getChallenge).collect(Collectors.toList())) {

--- a/src/main/java/com/example/onedaypiece/web/domain/challengeRecord/ChallengeRecordRepository.java
+++ b/src/main/java/com/example/onedaypiece/web/domain/challengeRecord/ChallengeRecordRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Set;
 
 public interface ChallengeRecordRepository extends JpaRepository<ChallengeRecord, Long> {
 

--- a/src/main/java/com/example/onedaypiece/web/dto/response/challenge/ChallengeMainResponseDto.java
+++ b/src/main/java/com/example/onedaypiece/web/dto/response/challenge/ChallengeMainResponseDto.java
@@ -11,11 +11,11 @@ import java.util.stream.Collectors;
 @Getter
 public class ChallengeMainResponseDto {
 
-    private List<ChallengeSourceResponseDto> slider;
-    private final List<ChallengeSourceResponseDto> popular = new ArrayList<>();
-    private final List<ChallengeSourceResponseDto> exercise = new ArrayList<>();
-    private final List<ChallengeSourceResponseDto> livinghabits = new ArrayList<>();
-    private final List<ChallengeSourceResponseDto> nodrinknosmoke = new ArrayList<>();
+    private final Set<ChallengeSourceResponseDto> slider = new HashSet<>();
+    private final Set<ChallengeSourceResponseDto> popular = new HashSet<>();
+    private final Set<ChallengeSourceResponseDto> exercise = new HashSet<>();
+    private final Set<ChallengeSourceResponseDto> livinghabits = new HashSet<>();
+    private final Set<ChallengeSourceResponseDto> nodrinknosmoke = new HashSet<>();
 
     public void addExercise(ChallengeSourceResponseDto responseDto) {
         exercise.add(responseDto);
@@ -37,7 +37,6 @@ public class ChallengeMainResponseDto {
     }
 
     public void addSlider(List<ChallengeSourceResponseDto> sliderSource) {
-        this.slider = new ArrayList<>();
         this.slider.addAll(sliderSource);
     }
 

--- a/src/main/java/com/example/onedaypiece/web/dto/response/challenge/ChallengeSourceResponseDto.java
+++ b/src/main/java/com/example/onedaypiece/web/dto/response/challenge/ChallengeSourceResponseDto.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @NoArgsConstructor
@@ -22,7 +24,7 @@ public class ChallengeSourceResponseDto {
     private String challengeImgUrl;
     private List<Long> challengeMember;
 
-    public ChallengeSourceResponseDto(Challenge challenge, List<ChallengeRecord> records) {
+    public ChallengeSourceResponseDto(Challenge challenge, Collection<ChallengeRecord> records) {
         this.challengeId = challenge.getChallengeId();
         this.challengeTitle = challenge.getChallengeTitle();
         this.categoryName = challenge.getCategoryName();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform = org.hibernate.dialect.MySQL5InnoDBDialect
 
 spring.jpa.properties.hibernate.show_sql = true
-spring.jpa.properties.hibernate.format_sql = true
+spring.jpa.properties.hibernate.format_sql = false
 
 #logging.level.org.hibernate.SQL=debug
 #logging.level.org.hibernate.type.descriptor.sql=trace


### PR DESCRIPTION
챌린지 메인페이지 api 카테고리 리스트가 중복값을 포함하지 않게 업데이트